### PR TITLE
在 `manifest.json` 中加入关于依赖的元数据

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
             "tag": "1.0.0"
         }
     },
+    "dependencies": ["LLAPI"],
     "platform": ["win32", "linux", "darwin"],
     "injects": {
         "renderer": "./src/renderer.js",


### PR DESCRIPTION
参考：
https://github.com/xtaw/LiteLoaderQQNT-Fake-Message/blob/3d3e93457941655865b2581f6e2a907db643734d/README.md?plain=1#L7-L8